### PR TITLE
fix: resolve Bad Gateway by adding outputFileTracingRoot for pnpm mon…

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,6 +39,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          submodules: recursive  # Foundry libs (forge-std, etc.) are git submodules
 
       - name: Setup pnpm
         uses: pnpm/action-setup@v3
@@ -50,6 +52,9 @@ jobs:
         with:
           node-version: '20'
           cache: 'pnpm'
+
+      - name: Install Foundry
+        uses: foundry-rs/foundry-toolchain@v1
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -116,6 +116,7 @@ jobs:
             NEXT_PUBLIC_DEFAULT_CHAIN_ID=8453
             NEXT_PUBLIC_REGISTRY_CONTRACT_ADDRESS=${{ secrets.NEXT_PUBLIC_REGISTRY_CONTRACT_ADDRESS }}
             NEXT_PUBLIC_BASE_RPC_URL=${{ secrets.NEXT_PUBLIC_BASE_RPC_URL }}
+            NEXT_PUBLIC_BASE_SEPOLIA_RPC_URL=${{ secrets.NEXT_PUBLIC_BASE_SEPOLIA_RPC_URL }}
           # Layer cache via GitHub Actions cache
           cache-from: type=gha
           cache-to: type=gha,mode=max

--- a/apps/web/.eslintrc.json
+++ b/apps/web/.eslintrc.json
@@ -1,0 +1,3 @@
+{
+  "extends": ["next/core-web-vitals"]
+}

--- a/apps/web/next.config.js
+++ b/apps/web/next.config.js
@@ -1,3 +1,5 @@
+const path = require('path')
+
 /** @type {import('next').NextConfig} */
 const nextConfig = {
   // Standalone output for Docker — produces a minimal self-contained Node server
@@ -10,6 +12,15 @@ const nextConfig = {
 
   // Transpile monorepo packages consumed by this app
   transpilePackages: ['@tips/shared'],
+
+  experimental: {
+    // Required for pnpm monorepos: tells Next.js file-tracer to resolve
+    // dependencies relative to the monorepo root so it correctly follows
+    // pnpm's virtual-store symlinks (node_modules/.pnpm/...) when building
+    // the standalone output. Without this, traced deps can be silently
+    // omitted, causing the server to crash with MODULE_NOT_FOUND at runtime.
+    outputFileTracingRoot: path.join(__dirname, '../../'),
+  },
 }
 
 module.exports = nextConfig


### PR DESCRIPTION
…orepo

Without outputFileTracingRoot set to the monorepo root, Next.js file-tracer resolves dependencies relative to apps/web/ and cannot correctly follow pnpm's virtual-store symlinks (node_modules/.pnpm/...). This silently drops traced deps from the standalone output, causing the Node server to crash with MODULE_NOT_FOUND at runtime — manifesting as a 502 Bad Gateway because nothing binds to port 3000 and Traefik gets connection refused.

Also adds the missing NEXT_PUBLIC_BASE_SEPOLIA_RPC_URL build arg to CI.

https://claude.ai/code/session_0199koiJmvsz7QnGztzArDfz